### PR TITLE
Add support to Instance for .get({plain: true})

### DIFF
--- a/src/instance.js
+++ b/src/instance.js
@@ -197,9 +197,12 @@ fakeModelInstance.prototype.set = function(key, val) {
  * @return {Any|Object} either the value of the key, or all the values if there is no key
  **/
 fakeModelInstance.prototype.get = function (key) {
-	if(key)
+	if(!key || key.plain) {
+		return _.clone(this._values);
+	}
+	else {
 		return this._values[key];
-	return _.clone(this._values);
+	}
 };
 
 /**

--- a/src/instance.js
+++ b/src/instance.js
@@ -194,7 +194,7 @@ fakeModelInstance.prototype.set = function(key, val) {
  * 
  * @instance
  * @param {String|Object} [key] Key to get the value for
- * @return {Any|Object} either the value of the key, or all the values if there is no key
+ * @return {Any|Object} either the value of the key, or all the values if there is no key or key is an object with plain set to true: {plain: true}
  **/
 fakeModelInstance.prototype.get = function (key) {
 	if(!key || key.plain) {

--- a/test/instance.spec.js
+++ b/test/instance.spec.js
@@ -145,6 +145,21 @@ describe('Instance', function () {
 			
 			inst.get('foo').should.be.exactly('bar');
 		});
+
+		it('should get the entire object if no paramater is provided', function () {
+			var inst = new Instance();
+			inst._values.foo = 'bar';
+			
+			inst.get().should.be.eql({foo: 'bar'});
+		});
+
+
+		it('should get the entire object if {plain: true} is passed', function () {
+			var inst = new Instance();
+			inst._values.foo = 'bar';
+			
+			inst.get().should.be.eql({foo: 'bar'});
+		});
 	});
 	
 	describe('#validate', function () {


### PR DESCRIPTION
When fetching a record in sequelizer, you can pass the option: {plain: true} to the get function. This strips the response to only include the column data. 

See docs: [http://docs.sequelizejs.com/manual/tutorial/instances.html#values-of-an-instance](http://docs.sequelizejs.com/manual/tutorial/instances.html#values-of-an-instance )

When using {plain: true} with the existing sequelize-mock implementation, it tries to use the object passed to get as the key to fetch a value from the data object. 
This pull request checks to see if the argument "key" in Instance.get contains {plain: true} and then, in alignment with the existing falsey check, returns the entire data object.  