### PR TITLE
Implement .model and .isDefined of the core API

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -275,6 +275,20 @@ Sequelize.prototype.define = function (name, obj, opts) {
 };
 
 /**
+ * Checks whether a model with the given name is defined.
+ * 
+ * Uses the `.models` property for lookup.
+ * 
+ * @see{@link define}
+ * @see{@link models}
+ * @param {String} name Name of the model
+ * @return {Boolean} True if the model is defined, false otherwise
+ */
+Sequelize.prototype.isDefined = function (name) {
+	return name in this.models && typeof this.models[name] !== 'undefined';	
+};
+
+/**
  * Run a mock query against the `QueryInterface` associated with this Sequelize instance
  * 
  * @return {Promise<Any>} The next result of a query as queued to the `QueryInterface`

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -289,6 +289,25 @@ Sequelize.prototype.isDefined = function (name) {
 };
 
 /**
+ * Fetch a Model which is already defined.
+ * 
+ * Uses the `.models` property for lookup.
+ * 
+ * @see{@link define}
+ * @see{@link models}
+ * @param {String} name Name of the model
+ * @return {Model} Mock model which was defined with the specified name
+ * @throws {Error} Will throw an error if the model is not defined (that is, if sequelize#isDefined returns false)
+ */
+Sequelize.prototype.model = function (name) {
+	if (!this.isDefined(name)) {
+		throw new Error(name + ' has not been defined');
+	}
+
+	return this.models[name];
+}
+
+/**
  * Run a mock query against the `QueryInterface` associated with this Sequelize instance
  * 
  * @return {Promise<Any>} The next result of a query as queued to the `QueryInterface`

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -204,6 +204,22 @@ describe('Sequelize', function () {
 			seq.define().should.be.instanceOf(ModelMock);
 		});
 	});
+
+	describe('#isDefined', function() {
+		it('should return true if the model is defined', function() {
+			var seq = new Sequelize();
+			seq.define('test', {});
+
+			seq.isDefined('test').should.be.true();
+		});
+
+		it('should return false if the model is not defined', function() {
+			var seq = new Sequelize();
+
+			seq.isDefined('test').should.be.true()
+		});
+	});
+
 	
 	describe('#query', function () {
 		it('should pass query along to QueryInterface', function () {

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -216,7 +216,7 @@ describe('Sequelize', function () {
 		it('should return false if the model is not defined', function() {
 			var seq = new Sequelize();
 
-			seq.isDefined('test').should.be.true()
+			seq.isDefined('test').should.be.false()
 		});
 	});
 

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -220,6 +220,24 @@ describe('Sequelize', function () {
 		});
 	});
 
+	describe('#model', function() {
+		it('should return a previously defined Mock Model referenced its name', function() {
+			var seq = new Sequelize();
+			var mock = seq.define('test', {});
+			seq.model('test').should.be.equal(mock);
+		});
+
+		it('should throw an error if there is no model with the specified name', function() {
+			var seq = new Sequelize();
+			var modelName = 'test';
+			var callModel = function() {
+				seq.model(modelName);
+			};
+
+			callModel.should.throw(Error);
+			callModel.should.throw(modelName + ' has not been defined');
+		});
+	});
 	
 	describe('#query', function () {
 		it('should pass query along to QueryInterface', function () {


### PR DESCRIPTION
This pull request implements [Sequelize#model](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-method-model) and [Sequelize#isDefined](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-method-isDefined) for issue #4.
