### PR TITLE
Mock DataTypes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 vNext
+  * Add DataType mock objects for use with any DataType funcitonality
   * Add support for conditional query result handling (thanks to @scinos)
   * Add support for `instance.get({ plain: true })` (thanks to @fredstrange)
   * Fix setting `isNewRecord` on instances to false after saving (issue #19; thanks to @scinos)

--- a/src/data-types.js
+++ b/src/data-types.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var util = require('util'),
+	_ = require('lodash');
+
 /**
  * These are the available DataTypes on the Sequelize class. You can access these on the
  * class object as seen here.
@@ -18,167 +21,525 @@
 
 function noop() {}
 
+/**
+ * Base abstract data type all other data types inherit from
+ * 
+ * @class Abstract
+ * @constructor
+ **/
+function Abstract () {
+}
+
+Abstract.prototype.toString =
+/**
+ * Returns the key this data type maps to in SQL
+ * 
+ * @instance
+ * @return {String} Key for this datatype
+ **/
+Abstract.prototype.toSql = function () {
+	return this.key;
+};
+
+/**
+ * Stringify a value for this data type
+ * 
+ * @instance
+ * @param {*} value The value to stringify
+ * @param {Object} options Any options the stringify for this datatype accepts
+ * @return {String} A string version value passed in
+ **/
+Abstract.prototype.stringify = function (value, options) {
+	if (this.$stringify) {
+		return this.$stringify(value, options);
+	}
+	return value + '';
+};
+
+/**
+ * Returns the key this data type maps to in SQL
+ * 
+ * @instance
+ * @return {String} Key for this datatype
+ **/
+Abstract.inherits = function (Inheriting) {
+	util.inherits(Inheriting, this);
+	_.extend(Inheriting, this);
+	
+	return Inheriting;
+};
+
+// In Sequelize these are mostly internal, but they are mapped here for parity
+Abstract.warn = noop;
+Abstract.prototype.dialectTypes = '';
+
+/**
+ * Mock string data type
+ *
+ * @property STRING
+ */
+var STRING = Abstract.inherits(function (length, binary) {
+	if (!(this instanceof STRING)) {
+		return new STRING(length, binary);
+	}
+	
+	this.options = typeof length === 'object' && length ? length : {
+		length: length || 255,
+		binary: binary,
+	};
+});
+STRING.prototype.key = STRING.key = 'STRING';
+STRING.prototype.BINARY = STRING;
+
+/**
+ * Mock char data type
+ *
+ * @property CHAR
+ */
+var CHAR = STRING.inherits(function (length, binary) {
+	if (!(this instanceof CHAR)) {
+		return new CHAR(length, binary);
+	}
+	STRING.apply(this, arguments);
+});
+CHAR.prototype.key = CHAR.key = 'CHAR';
+
+/**
+ * Mock text data type
+ *
+ * @property TEXT
+ */
+var TEXT = Abstract.inherits(function(length) {
+	if (!(this instanceof TEXT)) {
+		return new TEXT(length);
+	}
+	
+	this.options = typeof length === 'object' && length ? length : {
+		length: length || '',
+	};
+	this.key = (this.options.length || '').toUpperCase() + 'TEXT';
+});
+TEXT.prototype.key = TEXT.key = 'TEXT';
+
+/**
+ * Mock number data type for other number data types to inherit from
+ * 
+ * @private
+ * @property
+ **/
+var NUMBER = Abstract.inherits(function(options) {
+	this.options = options;
+});
+NUMBER.prototype.key = NUMBER.key = 'NUMBER';
+NUMBER.prototype.ZEROFILL = NUMBER.prototype.UNSIGNED = NUMBER;
+
+NUMBER.prototype.$stringify = function (value) {
+	if (isNaN(value)) {
+		return "'NaN'";
+	} else if (!isFinite(value)) {
+		return "'" + (value < 0 ? '-' : '') + "Infinity'";
+	}
+	return value + '';
+};
+
+/**
+ * Mock integer data type
+ *
+ * @property INTEGER
+ */
+var INTEGER = NUMBER.inherits(function(length) {
+	if (!(this instanceof INTEGER)) {
+		return new INTEGER(length);
+	}
+	
+	NUMBER.call(this, typeof length === 'object' && length ? length : {
+		length: length,
+	});
+});
+INTEGER.prototype.key = INTEGER.key = 'INTEGER';
+
+/**
+ * Mock big integer data type
+ *
+ * @property BIGINT
+ */
+var BIGINT = NUMBER.inherits(function(length) {
+	if (!(this instanceof BIGINT)) {
+		return new BIGINT(length);
+	}
+	
+	NUMBER.call(this, typeof length === 'object' && length ? length : {
+		length: length,
+	});
+});
+BIGINT.prototype.key = BIGINT.key = 'BIGINT';
+
+/**
+ * Mock float data type
+ *
+ * @property FLOAT
+ */
+var FLOAT = NUMBER.inherits(function(length, decimals) {
+	if (!(this instanceof FLOAT)) {
+		return new FLOAT(length, decimals);
+	}
+	
+	NUMBER.call(this, typeof length === 'object' && length ? length : {
+		length: length,
+		decimals: decimals,
+	});
+});
+FLOAT.prototype.key = FLOAT.key = 'FLOAT';
+
+/**
+ * Mock real number data type
+ *
+ * @property REAL
+ */
+var REAL = NUMBER.inherits(function(length, decimals) {
+	if (!(this instanceof REAL)) {
+		return new REAL(length, decimals);
+	}
+	
+	NUMBER.call(this, typeof length === 'object' && length ? length : {
+		length: length,
+		decimals: decimals,
+	});
+});
+REAL.prototype.key = REAL.key = 'REAL';
+
+/**
+ * Mock double data type
+ *
+ * @property DOUBLE
+ */
+var DOUBLE = NUMBER.inherits(function(length, decimals) {
+	if (!(this instanceof DOUBLE)) {
+		return new DOUBLE(length, decimals);
+	}
+	
+	NUMBER.call(this, typeof length === 'object' && length ? length : {
+		length: length,
+		decimals: decimals,
+	});
+});
+DOUBLE.prototype.key = DOUBLE.key = 'DOUBLE PRECISION';
+
+/**
+ * Mock decimal data type
+ *
+ * @property DECIMAL
+ */
+var DECIMAL = NUMBER.inherits(function(precision, scale) {
+	if (!(this instanceof DECIMAL)) {
+		return new DECIMAL(precision, scale);
+	}
+	
+	NUMBER.call(this, typeof precision === 'object' && precision ? precision : {
+		precision: precision,
+		scale: scale,
+	});
+});
+DECIMAL.prototype.key = DECIMAL.key = 'DECIMAL';
+
+/**
+ * Mock boolean data type
+ *
+ * @property BOOLEAN
+ */
+var BOOLEAN = Abstract.inherits(function () {
+	if (!(this instanceof BOOLEAN)) {
+		return new BOOLEAN();
+	}
+});
+BOOLEAN.prototype.key = BOOLEAN.key = 'BOOLEAN';
+
+/**
+ * Mock time data type
+ *
+ * @property TIME
+ */
+var TIME = Abstract.inherits(function () {
+	if (!(this instanceof TIME)) {
+		return new TIME();
+	}
+});
+TIME.prototype.key = TIME.key = 'TIME';
+
+/**
+ * Mock date data type
+ *
+ * @property DATE
+ */
+var DATE = Abstract.inherits(function (length) {
+	if (!(this instanceof DATE)) {
+		return new DATE(length);
+	}
+	
+	this.options = typeof length === 'object' && length ? length : {
+		length: length,
+	};
+});
+DATE.prototype.key = DATE.key = 'DATE';
+
+DATE.prototype.$stringify = function (date, options) {
+	return !(date instanceof Date) ? '' :
+		date.getFullYear() + '-' + _.padStart(date.getMonth() + 1, 2 , '0') + '-' + _.padStart(date.getDate(), 2, '0') + ' ' +
+		_.padStart(date.getHours(), 2, '0') + ':' + _.padStart(date.getMinutes(), 2, '0') + ':' +
+		_.padStart(date.getSeconds(), 2, '0') + '.' + _.padStart(date.getMilliseconds(), 3, '0') + ' Z';
+};
+
+/**
+ * Mock date-only data type
+ *
+ * @property DATEONLY
+ */
+var DATEONLY = Abstract.inherits(function () {
+	if (!(this instanceof DATEONLY)) {
+		return new DATEONLY();
+	}
+});
+DATEONLY.prototype.key = DATEONLY.key = 'DATEONLY';
+
+/**
+ * Mock hstore data type
+ *
+ * @property HSTORE
+ */
+var HSTORE = Abstract.inherits(function () {
+	if (!(this instanceof HSTORE)) {
+		return new HSTORE();
+	}
+});
+HSTORE.prototype.key = HSTORE.key = 'HSTORE';
+
+/**
+ * Mock JSON data type
+ *
+ * @property JSON
+ */
+var JSONT = Abstract.inherits(function () {
+	if (!(this instanceof JSONT)) {
+		return new JSONT();
+	}
+});
+JSONT.prototype.key = JSONT.key = 'JSON';
+JSONT.prototype.$stringify = function (value) {
+	return JSON.stringify(value);
+};
+
+/**
+ * Mock JSONB data type
+ *
+ * @property JSONB
+ */
+var JSONB = JSONT.inherits(function () {
+	if (!(this instanceof JSONB)) {
+		return new JSONB();
+	}
+});
+JSONB.prototype.key = JSONB.key = 'JSONB';
+
+/**
+ * Mock now datetime data type
+ *
+ * @property NOW
+ */
+var NOW = Abstract.inherits(function () {
+	if (!(this instanceof NOW)) {
+		return new NOW();
+	}
+});
+NOW.prototype.key = NOW.key = 'NOW';
+
+/**
+ * Mock blob data type
+ *
+ * @property BLOB
+ */
+var BLOB = Abstract.inherits(function (length) {
+	if (!(this instanceof BLOB)) {
+		return new BLOB(length);
+	}
+	
+	this.options = typeof length === 'object' && length ? length : {
+		length: length,
+	};
+});
+BLOB.prototype.key = BLOB.key = 'BLOB';
+BLOB.prototype.$stringify = function (value) {
+	return value.toString('hex');
+};
+
+/**
+ * Mock range data type
+ *
+ * @property RANGE
+ */
+var RANGE = Abstract.inherits(function (subtype) {
+	if (!(this instanceof RANGE)) {
+		return new RANGE(subtype);
+	}
+	
+	this.options = typeof subtype === 'object' && subtype ? subtype : {
+		subtype: new (subtype || INTEGER)(),
+	};
+});
+RANGE.prototype.key = RANGE.key = 'RANGE';
+
+/**
+ * Mock UUID data type
+ *
+ * @property UUID
+ */
+var UUID = Abstract.inherits(function () {
+	if (!(this instanceof UUID)) {
+		return new UUID();
+	}
+});
+UUID.prototype.key = UUID.key = 'UUID';
+
+/**
+ * Mock UUIDV1 data type
+ *
+ * @property UUIDV1
+ */
+var UUIDV1 = Abstract.inherits(function () {
+	if (!(this instanceof UUIDV1)) {
+		return new UUIDV1();
+	}
+});
+UUIDV1.prototype.key = UUIDV1.key = 'UUIDV1';
+
+/**
+ * Mock UUIDV4 data type
+ *
+ * @property UUIDV4
+ */
+var UUIDV4 = Abstract.inherits(function () {
+	if (!(this instanceof UUIDV4)) {
+		return new UUIDV4();
+	}
+});
+UUIDV4.prototype.key = UUIDV4.key = 'UUIDV4';
+
+/**
+ * Mock virutal data type (even though all test types are technically virtual)
+ *
+ * @property VIRTUAL
+ */
+var VIRTUAL = Abstract.inherits(function (subtype, fields) {
+	if (!(this instanceof VIRTUAL)) {
+		return new VIRTUAL(subtype, fields);
+	}
+	
+	this.returnType = new (subtype || INTEGER)();
+	this.fields = fields;
+});
+VIRTUAL.prototype.key = VIRTUAL.key = 'VIRTUAL';
+
+/**
+ * Mock enum data type
+ *
+ * @property ENUM
+ */
+var ENUM = Abstract.inherits(function (values) {
+	if (!(this instanceof ENUM)) {
+		return new ENUM(values);
+	}
+	
+	this.options = typeof values === 'object' && !Array.isArray(values) && values ? values : {
+		values: Array.isArray(values) ? values : Array.prototype.slice.call(arguments),
+	};
+	this.values = this.options.values;
+});
+ENUM.prototype.key = ENUM.key = 'ENUM';
+
+/**
+ * Mock array data type
+ *
+ * @property ARRAY
+ */
+var ARRAY = Abstract.inherits(function (subtype) {
+	if (!(this instanceof ARRAY)) {
+		return new ARRAY(subtype);
+	}
+	
+	this.options = typeof subtype === 'object' && subtype ? subtype : {
+		type: subtype,
+	};
+	this.type = typeof this.options.type === 'function' ? new this.options.type() : this.options.type;
+});
+ARRAY.prototype.key = ARRAY.key = 'ARRAY';
+
+ARRAY.is = function (obj, type) {
+	return obj.type instanceof type;
+};
+
+/**
+ * Mock geometry data type
+ *
+ * @property GEOMETRY
+ */
+var GEOMETRY = Abstract.inherits(function (subtype, srid) {
+	if (!(this instanceof GEOMETRY)) {
+		return new GEOMETRY(subtype, srid);
+	}
+	
+	this.options = typeof subtype === 'object' && subtype ? subtype : {
+		type: subtype,
+		srid: srid,
+	};
+	this.type = this.options.type;
+	this.srid = this.options.srid;
+});
+GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
+
+/**
+ * Mock geography data type
+ *
+ * @property GEOGRAPHY
+ */
+var GEOGRAPHY = Abstract.inherits(function (subtype, srid) {
+	if (!(this instanceof GEOGRAPHY)) {
+		return new GEOGRAPHY(subtype, srid);
+	}
+	
+	this.options = typeof subtype === 'object' && subtype ? subtype : {
+		type: subtype,
+		srid: srid,
+	};
+	this.type = this.options.type;
+	this.srid = this.options.srid;
+});
+GEOGRAPHY.prototype.key = GEOGRAPHY.key = 'GEOGRAPHY';
+
 module.exports = function (Sequelize) {
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.STRING    = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.CHAR      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.TEXT      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.INTEGER   = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.BIGINT    = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.FLOAT     = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.REAL      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.DOUBLE    = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.DECIMAL   = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.BOOLEAN   = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.TIME      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.DATE      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.DATEONLY  = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.HSTORE    = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.JSON      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.JSONB     = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.NOW       = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.BLOB      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.RANGE     = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.UUID      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.UUIDV1    = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.UUIDV4    = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.VIRTUAL   = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.ENUM      = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.ARRAY     = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.GEOMETRY  = noop;
-	/**
-	 * Mock data type. Simply a no-op function for use in definitions
-	 * 
-	 * @property
-	 **/
-	Sequelize.GEOGRAPHY = noop;
+	Sequelize.STRING    = STRING;
+	Sequelize.CHAR      = CHAR;
+	Sequelize.TEXT      = TEXT;
+	Sequelize.INTEGER   = INTEGER;
+	Sequelize.BIGINT    = BIGINT;
+	Sequelize.FLOAT     = FLOAT;
+	Sequelize.REAL      = REAL;
+	Sequelize.DOUBLE    = DOUBLE;
+	Sequelize.DECIMAL   = DECIMAL;
+	Sequelize.BOOLEAN   = BOOLEAN;
+	Sequelize.TIME      = TIME;
+	Sequelize.DATE      = DATE;
+	Sequelize.DATEONLY  = DATEONLY;
+	Sequelize.HSTORE    = HSTORE;
+	Sequelize.JSON      = JSONT;
+	Sequelize.JSONB     = JSONB;
+	Sequelize.NOW       = NOW;
+	Sequelize.BLOB      = BLOB;
+	Sequelize.RANGE     = RANGE;
+	Sequelize.UUID      = UUID;
+	Sequelize.UUIDV1    = UUIDV1;
+	Sequelize.UUIDV4    = UUIDV4;
+	Sequelize.VIRTUAL   = VIRTUAL;
+	Sequelize.ENUM      = ENUM;
+	Sequelize.ARRAY     = ARRAY;
+	Sequelize.GEOMETRY  = GEOMETRY;
+	Sequelize.GEOGRAPHY = GEOGRAPHY;
 };

--- a/test/data-types.spec.js
+++ b/test/data-types.spec.js
@@ -1,0 +1,823 @@
+'use strict';
+
+var should = require('should');
+var proxyquire = require('proxyquire').noCallThru();
+
+var DataTypes = proxyquire('../src/data-types', {
+	// No require's we need to override
+});
+
+describe('Data Types', function () {
+	
+	var MockObj;
+	
+	beforeEach(function () {
+		MockObj = {};
+		DataTypes(MockObj);
+	});
+	
+	
+	describe('.STRING', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('STRING');
+			MockObj.STRING.key.should.equal('STRING');
+			var verify = new MockObj.STRING();
+			verify.toSql().should.equal('STRING');
+			verify.should.have.property('BINARY').which.is.equal(MockObj.STRING);
+		});
+		
+		it('should cast to a STRING if called without new', function () {
+			var verify = MockObj.STRING();
+			verify.should.be.instanceof(MockObj.STRING);
+		});
+		
+		it('should record length and binary options', function () {
+			var verify = new MockObj.STRING(123, true);
+			verify.options.length.should.equal(123);
+			verify.options.binary.should.equal(true);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.STRING({ length: 123, binary: true });
+			verify.options.length.should.equal(123);
+			verify.options.binary.should.equal(true);
+		});
+		
+	});
+	
+	describe('.CHAR', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('CHAR');
+			MockObj.CHAR.key.should.equal('CHAR');
+			var ch = new MockObj.CHAR();
+			ch.toSql().should.equal('CHAR');
+			ch.should.have.property('BINARY').which.is.equal(MockObj.STRING);
+		});
+		
+		it('should cast to a CHAR if called without new', function () {
+			var verify = MockObj.CHAR();
+			verify.should.be.instanceof(MockObj.CHAR);
+		});
+		
+		it('should record length and binary options', function () {
+			var verify = new MockObj.CHAR(123, true);
+			verify.options.length.should.equal(123);
+			verify.options.binary.should.equal(true);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.CHAR({ length: 123, binary: true });
+			verify.options.length.should.equal(123);
+			verify.options.binary.should.equal(true);
+		});
+		
+	});
+	
+	describe('.TEXT', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('TEXT');
+			MockObj.TEXT.key.should.equal('TEXT');
+			var verify = new MockObj.TEXT();
+			verify.toSql().should.equal('TEXT');
+		});
+		
+		it('should cast to a TEXT if called without new', function () {
+			var verify = MockObj.TEXT();
+			verify.should.be.instanceof(MockObj.TEXT);
+		});
+		
+		it('should record length option', function () {
+			var verify = new MockObj.TEXT('tiny');
+			verify.options.length.should.equal('tiny');
+			verify.key.should.equal('TINYTEXT');
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.TEXT({ length: 'large' });
+			verify.options.length.should.equal('large');
+			verify.key.should.equal('LARGETEXT');
+		});
+		
+	});
+	
+	describe('.INTEGER', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('INTEGER');
+			MockObj.INTEGER.key.should.equal('INTEGER');
+			var verify = new MockObj.INTEGER();
+			verify.toSql().should.equal('INTEGER');
+			verify.should.have.property('UNSIGNED');
+			verify.should.have.property('ZEROFILL');
+		});
+		
+		it('should cast to a INTEGER if called without new', function () {
+			var verify = MockObj.INTEGER();
+			verify.should.be.instanceof(MockObj.INTEGER);
+		});
+		
+		it('should record length option', function () {
+			var verify = new MockObj.INTEGER(123);
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.INTEGER({ length: 123 });
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should return string NaN for stringify function', function () {
+			var verify = new MockObj.INTEGER();
+			verify.stringify(NaN).should.equal("'NaN'");
+		});
+		
+		it('should return string Infinity for stringify function', function () {
+			var verify = new MockObj.INTEGER();
+			verify.stringify(Infinity).should.equal("'Infinity'");
+			verify.stringify(-Infinity).should.equal("'-Infinity'");
+		});
+		
+		it('should return stringified number for stringify function', function () {
+			var verify = new MockObj.INTEGER();
+			verify.stringify(123).should.be.exactly("123");
+		});
+		
+	});
+	
+	describe('.BIGINT', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('BIGINT');
+			MockObj.BIGINT.key.should.equal('BIGINT');
+			var verify = new MockObj.BIGINT();
+			verify.toSql().should.equal('BIGINT');
+			verify.should.have.property('UNSIGNED');
+			verify.should.have.property('ZEROFILL');
+		});
+		
+		it('should cast to a BIGINT if called without new', function () {
+			var verify = MockObj.BIGINT();
+			verify.should.be.instanceof(MockObj.BIGINT);
+		});
+		
+		it('should record length option', function () {
+			var verify = new MockObj.BIGINT(123);
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.BIGINT({ length: 123 });
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should return string NaN for stringify function', function () {
+			var verify = new MockObj.BIGINT();
+			verify.stringify(NaN).should.equal("'NaN'");
+		});
+		
+		it('should return string Infinity for stringify function', function () {
+			var verify = new MockObj.BIGINT();
+			verify.stringify(Infinity).should.equal("'Infinity'");
+			verify.stringify(-Infinity).should.equal("'-Infinity'");
+		});
+		
+		it('should return stringified number for stringify function', function () {
+			var verify = new MockObj.BIGINT();
+			verify.stringify(123).should.be.exactly("123");
+		});
+		
+	});
+	
+	describe('.FLOAT', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('FLOAT');
+			MockObj.FLOAT.key.should.equal('FLOAT');
+			var verify = new MockObj.FLOAT();
+			verify.toSql().should.equal('FLOAT');
+			verify.should.have.property('UNSIGNED');
+			verify.should.have.property('ZEROFILL');
+		});
+		
+		it('should cast to a FLOAT if called without new', function () {
+			var verify = MockObj.FLOAT();
+			verify.should.be.instanceof(MockObj.FLOAT);
+		});
+		
+		it('should record length and decimals option', function () {
+			var verify = new MockObj.FLOAT(123, 4);
+			verify.options.length.should.equal(123);
+			verify.options.decimals.should.equal(4);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.FLOAT({ length: 123, decimals: 4 });
+			verify.options.length.should.equal(123);
+			verify.options.decimals.should.equal(4);
+		});
+		
+		it('should return string NaN for stringify function', function () {
+			var verify = new MockObj.FLOAT();
+			verify.stringify(NaN).should.equal("'NaN'");
+		});
+		
+		it('should return string Infinity for stringify function', function () {
+			var verify = new MockObj.FLOAT();
+			verify.stringify(Infinity).should.equal("'Infinity'");
+			verify.stringify(-Infinity).should.equal("'-Infinity'");
+		});
+		
+		it('should return stringified number for stringify function', function () {
+			var verify = new MockObj.FLOAT();
+			verify.stringify(1.23).should.be.exactly("1.23");
+		});
+		
+	});
+	
+	describe('.REAL', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('REAL');
+			MockObj.REAL.key.should.equal('REAL');
+			var verify = new MockObj.REAL();
+			verify.toSql().should.equal('REAL');
+			verify.should.have.property('UNSIGNED');
+			verify.should.have.property('ZEROFILL');
+		});
+		
+		it('should cast to a REAL if called without new', function () {
+			var verify = MockObj.REAL();
+			verify.should.be.instanceof(MockObj.REAL);
+		});
+		
+		it('should record length and decimals option', function () {
+			var verify = new MockObj.REAL(123, 4);
+			verify.options.length.should.equal(123);
+			verify.options.decimals.should.equal(4);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.REAL({ length: 123, decimals: 4 });
+			verify.options.length.should.equal(123);
+			verify.options.decimals.should.equal(4);
+		});
+		
+		it('should return string NaN for stringify function', function () {
+			var verify = new MockObj.REAL();
+			verify.stringify(NaN).should.equal("'NaN'");
+		});
+		
+		it('should return string Infinity for stringify function', function () {
+			var verify = new MockObj.REAL();
+			verify.stringify(Infinity).should.equal("'Infinity'");
+			verify.stringify(-Infinity).should.equal("'-Infinity'");
+		});
+		
+		it('should return stringified number for stringify function', function () {
+			var verify = new MockObj.REAL();
+			verify.stringify(1.23).should.be.exactly("1.23");
+		});
+		
+	});
+	
+	describe('.DOUBLE', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('DOUBLE');
+			MockObj.DOUBLE.key.should.equal('DOUBLE PRECISION');
+			var verify = new MockObj.DOUBLE();
+			verify.toSql().should.equal('DOUBLE PRECISION');
+			verify.should.have.property('UNSIGNED');
+			verify.should.have.property('ZEROFILL');
+		});
+		
+		it('should cast to a DOUBLE if called without new', function () {
+			var verify = MockObj.DOUBLE();
+			verify.should.be.instanceof(MockObj.DOUBLE);
+		});
+		
+		it('should record length and decimals option', function () {
+			var verify = new MockObj.DOUBLE(123, 4);
+			verify.options.length.should.equal(123);
+			verify.options.decimals.should.equal(4);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.DOUBLE({ length: 123, decimals: 4 });
+			verify.options.length.should.equal(123);
+			verify.options.decimals.should.equal(4);
+		});
+		
+		it('should return string NaN for stringify function', function () {
+			var verify = new MockObj.DOUBLE();
+			verify.stringify(NaN).should.equal("'NaN'");
+		});
+		
+		it('should return string Infinity for stringify function', function () {
+			var verify = new MockObj.DOUBLE();
+			verify.stringify(Infinity).should.equal("'Infinity'");
+			verify.stringify(-Infinity).should.equal("'-Infinity'");
+		});
+		
+		it('should return stringified number for stringify function', function () {
+			var verify = new MockObj.DOUBLE();
+			verify.stringify(1.23).should.be.exactly("1.23");
+		});
+		
+	});
+	
+	describe('.DECIMAL', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('DECIMAL');
+			MockObj.DECIMAL.key.should.equal('DECIMAL');
+			var verify = new MockObj.DECIMAL();
+			verify.toSql().should.equal('DECIMAL');
+			verify.should.have.property('UNSIGNED');
+			verify.should.have.property('ZEROFILL');
+		});
+		
+		it('should cast to a DECIMAL if called without new', function () {
+			var verify = MockObj.DECIMAL();
+			verify.should.be.instanceof(MockObj.DECIMAL);
+		});
+		
+		it('should record precision and scale option', function () {
+			var verify = new MockObj.DECIMAL(123, 4);
+			verify.options.precision.should.equal(123);
+			verify.options.scale.should.equal(4);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.DECIMAL({ precision: 123, scale: 4 });
+			verify.options.precision.should.equal(123);
+			verify.options.scale.should.equal(4);
+		});
+		
+		it('should return string NaN for stringify function', function () {
+			var verify = new MockObj.DECIMAL();
+			verify.stringify(NaN).should.equal("'NaN'");
+		});
+		
+		it('should return string Infinity for stringify function', function () {
+			var verify = new MockObj.DECIMAL();
+			verify.stringify(Infinity).should.equal("'Infinity'");
+			verify.stringify(-Infinity).should.equal("'-Infinity'");
+		});
+		
+		it('should return stringified number for stringify function', function () {
+			var verify = new MockObj.DECIMAL();
+			verify.stringify(1.23).should.be.exactly("1.23");
+		});
+		
+	});
+	
+	describe('.BOOLEAN', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('BOOLEAN');
+			MockObj.BOOLEAN.key.should.equal('BOOLEAN');
+			var verify = new MockObj.BOOLEAN();
+			verify.toSql().should.equal('BOOLEAN');
+		});
+		
+		it('should cast to a BOOLEAN if called without new', function () {
+			var verify = MockObj.BOOLEAN();
+			verify.should.be.instanceof(MockObj.BOOLEAN);
+		});
+		
+	});
+	
+	describe('.TIME', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('TIME');
+			MockObj.TIME.key.should.equal('TIME');
+			var verify = new MockObj.TIME();
+			verify.toSql().should.equal('TIME');
+		});
+		
+		it('should cast to a TIME if called without new', function () {
+			var verify = MockObj.TIME();
+			verify.should.be.instanceof(MockObj.TIME);
+		});
+		
+	});
+	
+	describe('.DATE', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('DATE');
+			MockObj.DATE.key.should.equal('DATE');
+			var verify = new MockObj.DATE();
+			verify.toSql().should.equal('DATE');
+		});
+		
+		it('should cast to a DATE if called without new', function () {
+			var verify = MockObj.DATE();
+			verify.should.be.instanceof(MockObj.DATE);
+		});
+		
+		it('should record length option', function () {
+			var verify = new MockObj.DATE(123, true);
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.DATE({ length: 123 });
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should return stringified date for stringify function', function () {
+			var verify = new MockObj.DATE();
+			var date = new Date();
+			date.setFullYear(2001);
+			date.setMonth(0);
+			date.setDate(1);
+			date.setHours(1);
+			date.setMinutes(1);
+			date.setSeconds(1);
+			date.setMilliseconds(1);
+			verify.stringify(date).should.be.exactly('2001-01-01 01:01:01.001 Z');
+		});
+		
+	});
+	
+	describe('.DATEONLY', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('DATEONLY');
+			MockObj.DATEONLY.key.should.equal('DATEONLY');
+			var verify = new MockObj.DATEONLY();
+			verify.toSql().should.equal('DATEONLY');
+		});
+		
+		it('should cast to a DATEONLY if called without new', function () {
+			var verify = MockObj.DATEONLY();
+			verify.should.be.instanceof(MockObj.DATEONLY);
+		});
+		
+	});
+	
+	describe('.HSTORE', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('HSTORE');
+			MockObj.HSTORE.key.should.equal('HSTORE');
+			var verify = new MockObj.HSTORE();
+			verify.toSql().should.equal('HSTORE');
+		});
+		
+		it('should cast to a HSTORE if called without new', function () {
+			var verify = MockObj.HSTORE();
+			verify.should.be.instanceof(MockObj.HSTORE);
+		});
+		
+	});
+	
+	describe('.JSON', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('JSON');
+			MockObj.JSON.key.should.equal('JSON');
+			var verify = new MockObj.JSON();
+			verify.toSql().should.equal('JSON');
+		});
+		
+		it('should cast to a JSON if called without new', function () {
+			var verify = MockObj.JSON();
+			verify.should.be.instanceof(MockObj.JSON);
+		});
+		
+		it('should return stringified json for stringify function', function () {
+			var verify = new MockObj.JSON();
+			verify.stringify({'foo':'bar'}).should.be.exactly('{"foo":"bar"}');
+		});
+		
+	});
+	
+	describe('.JSONB', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('JSONB');
+			MockObj.JSONB.key.should.equal('JSONB');
+			var verify = new MockObj.JSONB();
+			verify.toSql().should.equal('JSONB');
+		});
+		
+		it('should cast to a JSONB if called without new', function () {
+			var verify = MockObj.JSONB();
+			verify.should.be.instanceof(MockObj.JSONB);
+		});
+		
+		it('should return stringified json for stringify function', function () {
+			var verify = new MockObj.JSONB();
+			verify.stringify({'foo':'bar'}).should.be.exactly('{"foo":"bar"}');
+		});
+		
+	});
+	
+	describe('.NOW', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('NOW');
+			MockObj.NOW.key.should.equal('NOW');
+			var verify = new MockObj.NOW();
+			verify.toSql().should.equal('NOW');
+		});
+		
+		it('should cast to a NOW if called without new', function () {
+			var verify = MockObj.NOW();
+			verify.should.be.instanceof(MockObj.NOW);
+		});
+		
+	});
+	
+	describe('.BLOB', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('BLOB');
+			MockObj.BLOB.key.should.equal('BLOB');
+			var verify = new MockObj.BLOB();
+			verify.toSql().should.equal('BLOB');
+		});
+		
+		it('should cast to a BLOB if called without new', function () {
+			var verify = MockObj.BLOB();
+			verify.should.be.instanceof(MockObj.BLOB);
+		});
+		
+		it('should record length option', function () {
+			var verify = new MockObj.BLOB(123);
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.BLOB({ length: 123 });
+			verify.options.length.should.equal(123);
+		});
+		
+		it('should return stringified buffer for stringify function', function () {
+			var verify = new MockObj.BLOB();
+			verify.stringify(new Buffer('abc')).should.be.exactly('616263');
+		});
+		
+	});
+	
+	describe('.RANGE', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('RANGE');
+			MockObj.RANGE.key.should.equal('RANGE');
+			var verify = new MockObj.RANGE();
+			verify.toSql().should.equal('RANGE');
+		});
+		
+		it('should cast to a RANGE if called without new', function () {
+			var verify = MockObj.RANGE();
+			verify.should.be.instanceof(MockObj.RANGE);
+		});
+		
+		it('should default to INTEGER subtype option', function () {
+			var verify = new MockObj.RANGE();
+			verify.options.subtype.should.be.instanceof(MockObj.INTEGER);
+		});
+		
+		it('should record subtype option', function () {
+			var verify = new MockObj.RANGE(MockObj.STRING);
+			verify.options.subtype.should.be.instanceof(MockObj.STRING);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var obj = {};
+			var verify = new MockObj.RANGE({ subtype: obj });
+			verify.options.subtype.should.equal(obj);
+		});
+		
+	});
+	
+	describe('.UUID', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('UUID');
+			MockObj.UUID.key.should.equal('UUID');
+			var verify = new MockObj.UUID();
+			verify.toSql().should.equal('UUID');
+		});
+		
+		it('should cast to a UUID if called without new', function () {
+			var verify = MockObj.UUID();
+			verify.should.be.instanceof(MockObj.UUID);
+		});
+		
+	});
+	
+	describe('.UUIDV1', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('UUIDV1');
+			MockObj.UUIDV1.key.should.equal('UUIDV1');
+			var verify = new MockObj.UUIDV1();
+			verify.toSql().should.equal('UUIDV1');
+		});
+		
+		it('should cast to a UUIDV1 if called without new', function () {
+			var verify = MockObj.UUIDV1();
+			verify.should.be.instanceof(MockObj.UUIDV1);
+		});
+		
+	});
+	
+	describe('.UUIDV4', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('UUIDV4');
+			MockObj.UUIDV4.key.should.equal('UUIDV4');
+			var verify = new MockObj.UUIDV4();
+			verify.toSql().should.equal('UUIDV4');
+		});
+		
+		it('should cast to a UUIDV4 if called without new', function () {
+			var verify = MockObj.UUIDV4();
+			verify.should.be.instanceof(MockObj.UUIDV4);
+		});
+		
+	});
+	
+	describe('.VIRTUAL', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('VIRTUAL');
+			MockObj.VIRTUAL.key.should.equal('VIRTUAL');
+			var verify = new MockObj.VIRTUAL();
+			verify.toSql().should.equal('VIRTUAL');
+		});
+		
+		it('should cast to a VIRTUAL if called without new', function () {
+			var verify = MockObj.VIRTUAL();
+			verify.should.be.instanceof(MockObj.VIRTUAL);
+		});
+		
+		it('should default to INTEGER subtype option', function () {
+			var verify = new MockObj.VIRTUAL();
+			verify.returnType.should.be.instanceof(MockObj.INTEGER);
+		});
+		
+		it('should record subtype and field options', function () {
+			var fields = ['foo'];
+			var verify = new MockObj.VIRTUAL(MockObj.STRING, fields);
+			verify.returnType.should.be.instanceof(MockObj.STRING);
+			verify.fields.should.equal(fields);
+		});
+		
+	});
+	
+	describe('.ENUM', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('ENUM');
+			MockObj.ENUM.key.should.equal('ENUM');
+			var verify = new MockObj.ENUM();
+			verify.toSql().should.equal('ENUM');
+		});
+		
+		it('should cast to a ENUM if called without new', function () {
+			var verify = MockObj.ENUM();
+			verify.should.be.instanceof(MockObj.ENUM);
+		});
+		
+		it('should record values option as an array', function () {
+			var values = ['foo', 'bar'];
+			var verify = new MockObj.ENUM(values);
+			verify.options.values.should.equal(values);
+			verify.values.should.equal(values);
+		});
+		
+		it('should record values option as an options object', function () {
+			var values = ['foo', 'bar'];
+			var verify = new MockObj.ENUM({ values: values });
+			verify.options.values.should.equal(values);
+			verify.values.should.equal(values);
+		});
+		
+		it('should record values option as arguments passed in', function () {
+			var values = ['foo', 'bar'];
+			var verify = new MockObj.ENUM('foo', 'bar');
+			verify.options.values.length.should.equal(2);
+			verify.options.values[0].should.equal('foo');
+			verify.options.values[1].should.equal('bar');
+			verify.values.should.equal(verify.options.values);
+		});
+		
+	});
+	
+	describe('.ARRAY', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('ARRAY');
+			MockObj.ARRAY.key.should.equal('ARRAY');
+			var verify = new MockObj.ARRAY();
+			verify.toSql().should.equal('ARRAY');
+		});
+		
+		it('should cast to a ARRAY if called without new', function () {
+			var verify = MockObj.ARRAY();
+			verify.should.be.instanceof(MockObj.ARRAY);
+		});
+		
+		it('should record type option', function () {
+			var verify = new MockObj.ARRAY(MockObj.STRING);
+			verify.options.type.should.equal(MockObj.STRING);
+			verify.type.should.be.instanceof(MockObj.STRING);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.ARRAY({ type: MockObj.STRING });
+			verify.options.type.should.equal(MockObj.STRING);
+			verify.type.should.be.instanceof(MockObj.STRING);
+		});
+		
+		describe('.is', function () {
+			
+			it('should validate that an array is of a type', function () {
+				var verify = new MockObj.ARRAY(MockObj.STRING);
+				MockObj.ARRAY.is(verify, MockObj.STRING).should.be.true();
+			});
+			
+			it('should validate that an array is of a type', function () {
+				var verify = new MockObj.ARRAY(MockObj.INTEGER);
+				MockObj.ARRAY.is(verify, MockObj.STRING).should.be.false();
+			});
+			
+		});
+		
+	});
+	
+	describe('.GEOMETRY', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('GEOMETRY');
+			MockObj.GEOMETRY.key.should.equal('GEOMETRY');
+			var verify = new MockObj.GEOMETRY();
+			verify.toSql().should.equal('GEOMETRY');
+		});
+		
+		it('should cast to a GEOMETRY if called without new', function () {
+			var verify = MockObj.GEOMETRY();
+			verify.should.be.instanceof(MockObj.GEOMETRY);
+		});
+		
+		it('should record type and srid options', function () {
+			var verify = new MockObj.GEOMETRY(MockObj.STRING, 123);
+			verify.options.type.should.equal(MockObj.STRING);
+			verify.type.should.equal(MockObj.STRING);
+			verify.options.srid.should.equal(123);
+			verify.srid.should.equal(123);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.GEOMETRY({ type: MockObj.STRING, srid: 123 });
+			verify.options.type.should.equal(MockObj.STRING);
+			verify.type.should.equal(MockObj.STRING);
+			verify.options.srid.should.equal(123);
+			verify.srid.should.equal(123);
+		});
+		
+	});
+	
+	describe('.GEOGRAPHY', function () {
+		
+		it('should expose the property', function () {
+			MockObj.should.have.property('GEOGRAPHY');
+			MockObj.GEOGRAPHY.key.should.equal('GEOGRAPHY');
+			var verify = new MockObj.GEOGRAPHY();
+			verify.toSql().should.equal('GEOGRAPHY');
+		});
+		
+		it('should cast to a GEOGRAPHY if called without new', function () {
+			var verify = MockObj.GEOGRAPHY();
+			verify.should.be.instanceof(MockObj.GEOGRAPHY);
+		});
+		
+		it('should record type and srid options', function () {
+			var verify = new MockObj.GEOGRAPHY(MockObj.STRING, 123);
+			verify.options.type.should.equal(MockObj.STRING);
+			verify.type.should.equal(MockObj.STRING);
+			verify.options.srid.should.equal(123);
+			verify.srid.should.equal(123);
+		});
+		
+		it('should accept options as object instead of arguments', function () {
+			var verify = new MockObj.GEOGRAPHY({ type: MockObj.STRING, srid: 123 });
+			verify.options.type.should.equal(MockObj.STRING);
+			verify.type.should.equal(MockObj.STRING);
+			verify.options.srid.should.equal(123);
+			verify.srid.should.equal(123);
+		});
+		
+	});
+	
+});

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -20,7 +20,8 @@ var Sequelize = proxyquire('../src/sequelize', {
 	'./utils'  : UtilsMock,
 	'./errors' : ErrorMock,
 	'./queryinterface' : QueryInterfaceMock,
-	'../package.json' : PackageMock
+	'../package.json'  : PackageMock,
+	'./data-types'     : function () {}
 });
 
 describe('Sequelize', function () {
@@ -48,36 +49,6 @@ describe('Sequelize', function () {
 	it('should alias BaseError class', function () {
 		Sequelize.should.have.property('Error').which.is.equal(ErrorMock.BaseError);
 		Sequelize.prototype.should.have.property('Error').which.is.equal(ErrorMock.BaseError);
-	});
-	
-	it('should have data types exposed on class', function () {
-		Sequelize.should.have.property('STRING').which.is.a.Function();
-		Sequelize.should.have.property('CHAR').which.is.a.Function();
-		Sequelize.should.have.property('TEXT').which.is.a.Function();
-		Sequelize.should.have.property('INTEGER').which.is.a.Function();
-		Sequelize.should.have.property('BIGINT').which.is.a.Function();
-		Sequelize.should.have.property('FLOAT').which.is.a.Function();
-		Sequelize.should.have.property('REAL').which.is.a.Function();
-		Sequelize.should.have.property('DOUBLE').which.is.a.Function();
-		Sequelize.should.have.property('DECIMAL').which.is.a.Function();
-		Sequelize.should.have.property('BOOLEAN').which.is.a.Function();
-		Sequelize.should.have.property('TIME').which.is.a.Function();
-		Sequelize.should.have.property('DATE').which.is.a.Function();
-		Sequelize.should.have.property('DATEONLY').which.is.a.Function();
-		Sequelize.should.have.property('HSTORE').which.is.a.Function();
-		Sequelize.should.have.property('JSON').which.is.a.Function();
-		Sequelize.should.have.property('JSONB').which.is.a.Function();
-		Sequelize.should.have.property('NOW').which.is.a.Function();
-		Sequelize.should.have.property('BLOB').which.is.a.Function();
-		Sequelize.should.have.property('RANGE').which.is.a.Function();
-		Sequelize.should.have.property('UUID').which.is.a.Function();
-		Sequelize.should.have.property('UUIDV1').which.is.a.Function();
-		Sequelize.should.have.property('UUIDV4').which.is.a.Function();
-		Sequelize.should.have.property('VIRTUAL').which.is.a.Function();
-		Sequelize.should.have.property('ENUM').which.is.a.Function();
-		Sequelize.should.have.property('ARRAY').which.is.a.Function();
-		Sequelize.should.have.property('GEOMETRY').which.is.a.Function();
-		Sequelize.should.have.property('GEOGRAPHY').which.is.a.Function();
 	});
 	
 	describe('__constructor', function () {


### PR DESCRIPTION
Adds more fleshed out data type mocking. Data types should have almost a 1:1 parity with Sequelize now. Includes tests

Closes #3 