### PR TITLE
Fix Getting Started Code Error

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -13,7 +13,7 @@ Alternatively you can install the library by [downloading the latest code](https
 Because Sequelize Mock is meant to be a drop-in replacement for testing, it mirrors Sequelize in many ways including the base object's functionality. As such, you'll want to setup a fake DB connection, though you don't need any actual connection data.
 
 ```javascript
-var SequelizeMock = require('sequelize-mock')();
+var SequelizeMock = require('sequelize-mock');
 
 var dbMock = new SequelizeMock();
 ```


### PR DESCRIPTION
The example code for importing and initializing the library was trying to call the constructor twice. Removed the first call so the second with `new` works.

Close issue #26