### PR TITLE
Implement Sequelize#authenticate

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -346,4 +346,15 @@ Sequelize.prototype.literal = function (arg) {
 	return arg;
 };
 
+/**
+ * Simply returns a resolving promise
+ *
+ * @return {Promise}
+ */
+Sequelize.prototype.authenticate = function() {
+	return new bluebird(function (resolve) {
+		return resolve();
+	});
+};
+
 module.exports = Sequelize;

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -257,4 +257,10 @@ describe('Sequelize', function () {
 		});
 	});
 	
+	describe('#authenticate', function () {
+		it('should simply return a resolving promise', (done) => {
+			var seq = new Sequelize();
+			seq.authenticate().then(done).catch(done);
+		})
+  });
 });


### PR DESCRIPTION
This pull request implements [Sequelize#authenticate](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-method-authenticate) for issue #4 .

Any suggestions on how to implement the 'Invalid credentials' error?