### PR TITLE
Adds Import Functionality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 vNext
+  * Add `sequelize.import` support
+  * Add `sequelize.$overrideImport` test functionality to allow overriding imported module paths
   * Add support for `Model.findAndCount()` and it's alias `Model.findAndCountAll()` (thanks to @TerryMooreII)
 
 v0.9.1 - 3aeaa05 - Sep 21st 2017

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -33,6 +33,13 @@ Options passed into the Sequelize initialization
 
 
 
+<a name="importCache"></a>
+### .importCache
+
+Used to cache and override model imports for easy mock model importing
+
+
+
 <a name="models"></a>
 ### .models
 
@@ -151,6 +158,25 @@ Clears any queued results from `$queueResult` or `$queueFailure` <br>**Alias** $
 
 
 
+<a name="overrideImport"></a>
+## $overrideImport(importPath, overridePath)
+
+Overrides a path used for import
+
+**See**
+
+ - [import](#import)
+
+###  Parameters
+
+Name | Type | Description
+--- | --- | ---
+importPath | String | The original path that import will be called with
+overridePath | String | The path that should actually be used for resolving. If this path is relative, it will be relative to the file calling the import function
+
+
+
+
 <a name="getDialect"></a>
 ## getDialect() -> String
 
@@ -237,6 +263,30 @@ name | String | Name of the model
 
 ###  Return
 `Boolean`: True if the model is defined, false otherwise
+
+
+
+<a name="import"></a>
+## import(path) -> Any
+
+Imports a given model from the provided file path. Files that are imported should
+export a function that accepts two parameters, this sequelize instance, and an object
+with all of the available datatypes
+
+Before importing any modules, it will remap any paths that were overridden using the
+`$overrideImport` test function. This method is most helpful when used to make the
+SequelizeMock framework import your mock models instead of the real ones in your test
+code.
+
+###  Parameters
+
+Name | Type | Description
+--- | --- | ---
+path | String | Path of the model to import. Can be relative or absolute
+
+
+###  Return
+`Any`: The result of evaluating the imported file's function
 
 
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -74,6 +74,13 @@ str | String | Word to convert to its plural form
 
 
 
+<a name="stack"></a>
+## stack()
+
+Gets the current stack frame
+
+
+
 <a name="lodash"></a>
 ## lodash
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -38,6 +38,27 @@ var UserMock = dbMock.define('user', {
 
 ## Swapping Model for Mocks
 
+### Using `Sequelize.import()`
+
+In SequelizeMock, we provide the same `import()` functionality that Sequelize provides, with the added ability to override any given imported path with your mock paths.
+
+Using the `$overrideImport` method, you can simply define a mapping between your model and your mock object.
+
+```javascript
+// If your Sequelize code looks like this
+sequelize.import('./users/model.js');
+
+// Your test code can simply override the import so your code will function as expected
+sequelize.$overrideImport('./users/model.js', './users/mock.js');
+
+// Now an import for your users model will actually import your user mock file instead
+sequelize.import('./users/model.js'); // Will load './users/mock.js' instead
+```
+
+**Note that relative paths are relative to the file calling the `import` function, and not to your test code.**
+
+### Using `require()`
+
 There are a number of libraries out there that can be used to replace `require()` dependencies with mock objects. You can simply use one of these libraries to replace the Sequelize Mock object into your code and it should run exactly as you would expect.
 
 Here is an example of doing so with [proxyquire](https://www.npmjs.com/package/proxyquire)
@@ -54,7 +75,7 @@ var myModule = proxyquire('user.controller', {
 });
 ```
 
-### Some Mock Injection Libraries
+#### Some Mock Injection Libraries
  * [proxyquire](https://www.npmjs.com/package/proxyquire)
  * [mockery](https://www.npmjs.com/package/mockery)
  * [mock-require](https://www.npmjs.com/package/mock-require)

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -7,12 +7,14 @@
  * @fileOverview Mock class for the base Sequelize class
  */
 
-var _ = require('lodash'),
+var path = require('path'),
+	_ = require('lodash'),
 	bluebird = require('bluebird'),
 	Model = require('./model'),
 	Instance = require('./instance'),
 	Utils = require('./utils'),
 	Errors = require('./errors'),
+	DataTypes = require('./data-types')({}),
 	QueryInterface = require('./queryinterface');
 
 /**
@@ -50,6 +52,14 @@ function Sequelize(database, username, password, options) {
 	this.options = _.extend({
 		dialect: 'mock',
 	}, options || {});
+	
+	/**
+	 * Used to cache and override model imports for easy mock model importing
+	 * 
+	 * @member Sequelize
+	 * @property
+	 **/
+	this.importCache = {};
 	
 	/**
 	 * Models that have been defined in this Sequelize Mock instances
@@ -213,6 +223,17 @@ Sequelize.prototype.$queueQueryClear =
 Sequelize.prototype.$cqq =
 Sequelize.prototype.$qqc = Sequelize.prototype.$clearQueue;
 
+/**
+ * Overrides a path used for import
+ * 
+ * @see {@link import}
+ * @param {String} importPath The original path that import will be called with
+ * @param {String} overridePath The path that should actually be used for resolving. If this path is relative, it will be relative to the file calling the import function
+ **/
+Sequelize.prototype.$overrideImport = function (realPath, mockPath) {
+	this.importCache[realPath] = mockPath;
+};
+
 /* Mock Functionality
  * 
  */
@@ -286,6 +307,38 @@ Sequelize.prototype.define = function (name, obj, opts) {
  */
 Sequelize.prototype.isDefined = function (name) {
 	return name in this.models && typeof this.models[name] !== 'undefined';	
+};
+
+/**
+ * Imports a given model from the provided file path. Files that are imported should
+ * export a function that accepts two parameters, this sequelize instance, and an object
+ * with all of the available datatypes
+ * 
+ * Before importing any modules, it will remap any paths that were overridden using the
+ * `$overrideImport` test function. This method is most helpful when used to make the
+ * SequelizeMock framework import your mock models instead of the real ones in your test
+ * code.
+ * 
+ * @param {String} path Path of the model to import. Can be relative or absolute
+ * @return {Any} The result of evaluating the imported file's function
+ **/
+Sequelize.prototype.import = function (importPath) {
+	if(typeof this.importCache[importPath] === 'string') {
+		importPath = this.importCache[importPath];
+	}
+	
+	if(path.normalize(importPath) !== path.resolve(importPath)) {
+		// We're relative, and need the calling files location
+		var callLoc = path.dirname(Utils.stack().getFileName());
+		
+		importPath = path.resolve(callLoc, importPath);
+	}
+	
+	if(this.importCache[importPath] === 'string' || !this.importCache[importPath]) {
+		this.importCache[importPath] = require(importPath)(this, DataTypes);
+	}
+	
+	return this.importCache[importPath];
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,6 +52,20 @@ exports.pluralize = function(str) {
 };
 
 /**
+ * Gets the current stack frame
+ * 
+ **/
+exports.stack = function () {
+	// Stash original stack prep
+	var prepareStackTrace = Error.prepareStackTrace;
+	Error.prepareStackTrace = function (_, s) { return s; };
+	var curr = {};
+	Error.captureStackTrace(curr, exports.stack);
+	Error.prepareStackTrace = prepareStackTrace;
+	return curr.stack;
+};
+
+/**
  * Exposed version of the lodash library
  * 
  * @name lodash

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -5,7 +5,16 @@ var bluebird = require('bluebird');
 var proxyquire = require('proxyquire').noCallThru();
 
 var ModelMock = function () {};
-var UtilsMock = {};
+var PathMock = {
+	normalize: function (p) { return p },
+	resolve: function (p) { return p },
+	dirname: function (p) { return p },
+};
+
+var UtilsMock = {
+	stack: function () { return {}; },
+};
+
 var PackageMock = {
 	version: 'test',
 };
@@ -15,13 +24,21 @@ var ErrorMock = {
 };
 var QueryInterfaceMock = function () {};
 
+var lastImportTestCall;
+function importTestFunc() {
+	lastImportTestCall = arguments;
+}
+
 var Sequelize = proxyquire('../src/sequelize', {
+	'path'     : PathMock,
 	'./model'  : ModelMock,
 	'./utils'  : UtilsMock,
 	'./errors' : ErrorMock,
 	'./queryinterface' : QueryInterfaceMock,
 	'../package.json'  : PackageMock,
-	'./data-types'     : function () {}
+	'./data-types'     : function () {},
+	
+	'import-test'      : importTestFunc,
 });
 
 describe('Sequelize', function () {
@@ -141,7 +158,7 @@ describe('Sequelize', function () {
 			seq = new Sequelize();
 		});
 		
-		it('should queue a result against the QueryInterface', function () {
+		it('should clear queue of results in the QueryInterface', function () {
 			var run = 0;
 			seq.queryInterface = {
 				$clearQueue: function (res) {
@@ -150,6 +167,19 @@ describe('Sequelize', function () {
 			};
 			seq.$clearQueue();
 			run.should.equal(1);
+		});
+	});
+	
+	describe('#$overrideImport', function () {
+		var seq;
+		beforeEach(function () {
+			seq = new Sequelize();
+		});
+		
+		it('should override an import path in the importCache', function () {
+			seq.importCache = {};
+			seq.$overrideImport('foo', 'bar');
+			seq.importCache.should.have.property('foo').which.is.exactly('bar');
 		});
 	});
 	
@@ -190,7 +220,60 @@ describe('Sequelize', function () {
 			seq.isDefined('test').should.be.false()
 		});
 	});
-
+	
+	describe('#import', function () {
+		var seq, resolve, stack;
+		beforeEach(function () {
+			seq = new Sequelize();
+			lastImportTestCall = null;
+			resolve = PathMock.resolve;
+			stack = UtilsMock.stack;
+		});
+		
+		afterEach(function () {
+			PathMock.resolve = resolve;
+			UtilsMock.stack = stack;
+		});
+		
+		it('should return an already imported model', function () {
+			var findItem = {};
+			seq.importCache = {
+				'foo': findItem,
+			};
+			seq.import('foo').should.be.exactly(findItem);
+		});
+		
+		it('should import a model from the given path', function () {
+			seq.import('import-test');
+			should(lastImportTestCall).not.be.Null();
+			lastImportTestCall[0].should.be.exactly(seq);
+		});
+		
+		it('should turn a relative path into an absolute path', function () {
+			var pathRun = 0;
+			var stackRun = 0;
+			PathMock.resolve = function () { pathRun++; return './bar'; };
+			UtilsMock.stack = function () { stackRun++; return { getFileName: function () { return 'baz'; }}; };
+			var findItem = {};
+			
+			seq.importCache = {
+				'./bar': findItem,
+			};
+			seq.import('./foo').should.be.exactly(findItem);
+			pathRun.should.be.exactly(2);
+			stackRun.should.be.exactly(1);
+		});
+		
+		it('should import a replaced model from an overridden import', function () {
+			var findItem = {};
+			seq.importCache = {
+				'foo': 'bar',
+				'bar': findItem,
+			};
+			seq.import('foo').should.be.exactly(findItem);
+		});
+	});
+	
 	describe('#model', function() {
 		it('should return a previously defined Mock Model referenced its name', function() {
 			var seq = new Sequelize();

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -80,4 +80,35 @@ describe('Utils', function () {
 		});
 	});
 	
+	describe('#stack', function () {
+		var captureStack;
+		beforeEach(function () {
+			captureStack = Error.captureStackTrace;
+		});
+		
+		afterEach(function () {
+			Error.captureStackTrace = captureStack;
+		});
+		
+		it('should capture and return the stack trace', function () {
+			var arg1, arg2;
+			Error.captureStackTrace = function (obj, fn) {
+				arg1 = obj;
+				arg2 = fn;
+				obj.stack = 'bar';
+			};
+			
+			var ret = Utils.stack();
+			
+			// We need to restore nomality here so that the asserts and things can work properly
+			Error.captureStackTrace = captureStack;
+			
+			should(arg1).be.Object();
+			should(arg2).be.Function();
+			
+			ret.should.equal('bar');
+		});
+		
+	});
+	
 });


### PR DESCRIPTION
Adds the ability to import models into the Sequelize Mock interface. Also adds the test capability to override imports to reroute paths to mock models.

Addresses `.import` support in #4 