### PR TITLE
Fix some issues with Sequelize compatibility

### DIFF
--- a/src/data-types.js
+++ b/src/data-types.js
@@ -546,4 +546,6 @@ module.exports = function (Sequelize) {
 	Sequelize.ARRAY     = ARRAY;
 	Sequelize.GEOMETRY  = GEOMETRY;
 	Sequelize.GEOGRAPHY = GEOGRAPHY;
+	
+	return Sequelize;
 };


### PR DESCRIPTION
We need to return the object used to store the datatypes, otherwise sequelizeInstance.import is broken.

See [here](https://github.com/BlinkUX/sequelize-mock/blob/b81568432239f95ef5f4a866b356143fe7ba4ff7/src/sequelize.js#L338) for more info 

Apologies for the whitespace diff, my editor removes them automatically. View the diff [here](./39/files?w=1) without them