### PR TITLE
Add editorconfig override for files needing spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true
+
+[{package.json,*.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
We have a few files (yml, and the package.json) which use spaces. These are needed or preferred by their respective consuming systems, so we'll match those to that style.