### PR TITLE
Add support for mocking .addScope()

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -240,6 +240,14 @@ fakeModel.prototype.scope = function () {
 };
 
 /**
+ * No-op that returns a void.
+ * 
+ * @instance
+ * @return {undefined}
+ **/
+fakeModel.prototype.addScope = function () {};
+
+/**
  * Executes a mock query to find all of the instances with any provided options. Without
  * any other configuration, the default behavior when no queueud query result is present
  * is to create an array of a single result based on the where query in the options and

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -162,7 +162,7 @@ describe('Model', function () {
 			// mdl.should.have.property('schema').which.is.a.Function();
 			mdl.should.have.property('getTableName').which.is.a.Function();
 			mdl.should.have.property('unscoped').which.is.a.Function();
-			// mdl.should.have.property('addScope').which.is.a.Function();
+			mdl.should.have.property('addScope').which.is.a.Function();
 			mdl.should.have.property('scope').which.is.a.Function();
 			mdl.should.have.property('find').which.is.a.Function();
 			mdl.should.have.property('findAll').which.is.a.Function();


### PR DESCRIPTION
This adds .addScope() sequelize function, and enables the check for it in tests.

Here is a [link to Sequelize's implementation](https://github.com/sequelize/sequelize/blob/3cea5c4f84e0b7a5c0ef5548d318d786d495eb4e/lib/model.js#L1291) of that function.