### PR TITLE
fixed support of clear handlers in models

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -188,6 +188,20 @@ function fakeModel (name, defaults, opts) {
 	 * @return {QueryInterface} model instance of QueryInterface
 	 **/
 	this.$clearQueue = this.$queueClear = this.$queryInterface.$clearQueue.bind(this.$queryInterface);
+	/**
+	 * Clears any handlers for this model.
+	 * 
+	 * @example
+	 * UserMock.$clearHandlers();
+	 * 
+	 * @instance
+	 * @method $clearHandlers
+	 * @see {@link ./queryinterface.md#clearHandlers|QueryInterface.$clearHandlers}
+	 * @param {Object} [options] Options used when returning the result
+	 * @param {Boolean} [options.propagateClear] Propagate this clear up to any parent `QueryInterface`s. Defaults to false
+	 * @return {QueryInterface} model instance of QueryInterface
+	 **/
+	this.$clearHandlers = this.$queryInterface.$clearHandlers.bind(this.$queryInterface);
 	this.$query = this.$queryInterface.$query.bind(this.$queryInterface);
 }
 


### PR DESCRIPTION
hi,

i am trying to clear handlers in models but unable to do so.
when i checked the module files then found it's not bind in models

**this line should be added after line 190 in model.js**
this.$clearHandlers = this.$queryInterface.$clearHandlers.bind(this.$queryInterface);