### PR TITLE
#36: Adding ES6 style module support

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -334,8 +334,13 @@ Sequelize.prototype.import = function (importPath) {
 		importPath = path.resolve(callLoc, importPath);
 	}
 	
-	if(this.importCache[importPath] === 'string' || !this.importCache[importPath]) {
-		this.importCache[importPath] = require(importPath)(this, DataTypes);
+	if(this.importCache[importPath] === 'string' || !this.importCache[importPath]) {		
+		var defineCall = arguments.length > 1 ? arguments[1] : require(importPath);
+		if(typeof defineCall === 'object') {
+			// ES6 module compatibility
+			defineCall = defineCall.default;
+		}
+		this.importCache[importPath] = defineCall(this, DataTypes);
 	}
 	
 	return this.importCache[importPath];

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -39,6 +39,7 @@ var Sequelize = proxyquire('../src/sequelize', {
 	'./data-types'     : function () {},
 	
 	'import-test'      : importTestFunc,
+	'import-test-es6'  : { default: importTestFunc },
 });
 
 describe('Sequelize', function () {
@@ -271,6 +272,18 @@ describe('Sequelize', function () {
 				'bar': findItem,
 			};
 			seq.import('foo').should.be.exactly(findItem);
+		});
+
+		it('should import an es6 model from the given path', function () {
+			seq.import('import-test-es6');
+			should(lastImportTestCall).not.be.Null();
+			lastImportTestCall[0].should.be.exactly(seq);
+		});
+
+		it('should import a model function as the second argument (for meteor compatibility)', function () {
+			seq.import('import-test', importTestFunc);
+			should(lastImportTestCall).not.be.Null();
+			lastImportTestCall[0].should.be.exactly(seq);
 		});
 	});
 	


### PR DESCRIPTION
Also adding support for frameworks that override the `require()` function (like Meteor).

http://docs.sequelizejs.com/manual/tutorial/models-definition.html#import