### PR TITLE
Change findById to findByPk

### DIFF
--- a/docs/api/instance.md
+++ b/docs/api/instance.md
@@ -175,6 +175,38 @@ Name | Type | Description
 
 
 
+<a name="getDataValue"></a>
+## getDataValue(key) -> Any
+
+Get plain value
+
+###  Parameters
+
+Name | Type | Description
+--- | --- | ---
+key | String | Key yo get the value for
+
+
+###  Return
+`Any`: 
+
+
+
+<a name="setDataValue"></a>
+## setDataValue(key, value)
+
+Set plain value
+
+###  Parameters
+
+Name | Type | Description
+--- | --- | ---
+key | String | Key yo get the value for
+value | Any | 
+
+
+
+
 <a name="validate"></a>
 ## validate() -> Promise.&#60;ValidationErrorItem|undefined&#62;
 

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -227,6 +227,16 @@ No-op that returns the current object
 
 
 
+<a name="addScope"></a>
+## addScope() -> 
+
+No-op that returns a void.
+
+###  Return
+``: 
+
+
+
 <a name="findAll"></a>
 ## findAll([options]) -> Promise.&#60;Array.&#60;Instance&#62;&#62;
 
@@ -306,8 +316,8 @@ Name | Type | Description
 
 
 
-<a name="findById"></a>
-## findById(id) -> Promise.&#60;Instance&#62;
+<a name="findByPk"></a>
+## findByPk(id) -> Promise.&#60;Instance&#62;
 
 Executes a mock query to find an instance with the given ID value. Without any other
 configuration, the default behavior when no queueud query result is present is to

--- a/docs/docs/mock-queries.md
+++ b/docs/docs/mock-queries.md
@@ -98,7 +98,7 @@ User.$useHandler(function(query, queryOptions, done) {
 	if (query === "findOne") return User.build({id: 1});
 });
 User.$useHandler(function(query, queryOptions, done) {
-	if (query === "findById") return User.build({id: queryOptions[0]});
+	if (query === "findByPk") return User.build({id: queryOptions[0]});
 });
 User.$useHandler(function(query, queryOptions, done) {
 	if (query === "findOrCreate") return User.build({id:1000});
@@ -107,7 +107,7 @@ User.$useHandler(function(query, queryOptions, done) {
 User.findOne().then(function (user) {
 	user.get('id'); // === 1
 });
-User.findById(123).then(function (user) {
+User.findByPk(123).then(function (user) {
 	user.get('id'); // === 123
 });
 User.findOrCreate().then(function (user) {

--- a/src/model.js
+++ b/src/model.js
@@ -346,11 +346,11 @@ fakeModel.prototype.findAndCountAll =  function (options) {
  * @param {Integer} id ID of the instance
  * @return {Promise<Instance>} Promise that resolves with an instance with the given ID
  **/
-fakeModel.prototype.findById = function (id) {
+fakeModel.prototype.findByPk = function (id) {
 	var self = this;
 	
 	return this.$query({
-		query: "findById",
+		query: "findByPk",
 		queryOptions: arguments,
 		fallbackFn: !this.options.autoQueryFallback ? null : function () {
 			return Promise.resolve( self.build({ id: id }) );

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -168,7 +168,7 @@ describe('Model', function () {
 			mdl.should.have.property('findAll').which.is.a.Function();
 			mdl.should.have.property('findAndCount').which.is.a.Function();
 			mdl.should.have.property('findAndCountAll').which.is.a.Function();
-			mdl.should.have.property('findById').which.is.a.Function();
+			mdl.should.have.property('findByPk').which.is.a.Function();
 			mdl.should.have.property('findOne').which.is.a.Function();
 			// mdl.should.have.property('aggregate').which.is.a.Function();
 			// mdl.should.have.property('count').which.is.a.Function();
@@ -373,14 +373,14 @@ describe('Model', function () {
 		});
 	});
 	
-	describe('#findById', function () {
+	describe('#findByPk', function () {
 		var mdl;
 		beforeEach(function () {
 			mdl = new Model('foo');
 		});
 		
 		it('should find a row with the given id', function (done) {
-			mdl.findById(1234)
+			mdl.findByPk(1234)
 				.fallbackFn().then(function (inst) {
 					inst._args[0].id.should.equal(1234);
 					done();
@@ -389,17 +389,17 @@ describe('Model', function () {
 		
 		it('should not pass along a fallback function if auto fallback is turned off', function () {
 			mdl.options.autoQueryFallback = false;
-			should.not.exist(mdl.findById().fallbackFn);
+			should.not.exist(mdl.findByPk().fallbackFn);
 		});
 		
 		it('should pass query info to the QueryInterface instance', function(done) {
 			mdl.$query = function(options) {
-				options.query.should.equal('findById');
+				options.query.should.equal('findByPk');
 				options.queryOptions.length.should.equal(1);
 				options.queryOptions[0].should.equal(123);
 				done();
 			}
-			mdl.findById(123);
+			mdl.findByPk(123);
 		});
 	});
 	


### PR DESCRIPTION
Hi, 

This changes the `findById` method to `findByPk`, which is a change made in Sequelize v5. I realize there are other changes made from v4 to v5 that, if this repo chooses to support v5, should be implemented. However, this was an easy fix and something I personally needed, so I thought I'd create a PR anyway. This should close #71.

I cannot find much information on what versions of Sequelize this lib supports - and since this is currently version 0.10.2 I'm guessing no real plans have been made yet. If any plans are made, I'm more than happy to either add more changes to this PR or help in creating more PR's that make the switch from v4 to v5 as explained here: http://docs.sequelizejs.com/manual/upgrade-to-v5.html

Thanks for all your great work!