### PR TITLE
Update the transaction method signature

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -378,19 +378,28 @@ Sequelize.prototype.query = function () {
  * This function will simulate the wrapping of a set of queries in a transaction. Because
  * Sequelize Mock does not run any actual queries, there is no difference between code
  * run through transactions and those that aren't.
- * 
- * @param {Function} [fn] Optional function to run as a tranasction
+ *
+ * @param {Object}   [options] Transaction options
+ * @param {string}   [options.type='DEFERRED'] See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
+ * @param {string}   [options.isolationLevel] See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
+ * @param {string}   [options.deferrable] Sets the constraints to be deferred or immediately checked. See `Sequelize.Deferrable`. PostgreSQL Only
+ * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Function} [autoCallback] The callback is called with the transaction object, and should return a promise. If the promise is resolved, the transaction commits; if the promise rejects, the transaction rolls back
  * @return {Promise} Promise that resolves the code is successfully run, otherwise it is rejected
  */
-Sequelize.prototype.transaction = function (fn) {
-	if(!fn) {
-		fn = function (t) {
+Sequelize.prototype.transaction = function (options, autoCallback) {
+	if (typeof options === 'function') {
+		autoCallback = options;
+		options = undefined;
+	}
+	if(!autoCallback) {
+		autoCallback = function (t) {
 			return bluebird.resolve(t);
 		};
 	}
 	return new bluebird(function (resolve, reject) {
 		// TODO Return mock transaction object
-		return fn({}).then(resolve, reject);
+		return autoCallback({}).then(resolve, reject);
 	});
 };
 

--- a/test/sequelize.spec.js
+++ b/test/sequelize.spec.js
@@ -323,6 +323,18 @@ describe('Sequelize', function () {
 	});
 	
 	describe('#transaction', function () {
+		it('should allow an options object as the first optional argument', function (done) {
+			var seq = new Sequelize(),
+				count = 0;
+			seq.transaction({}, function () {
+				count++;
+				return Promise.resolve();
+			}).then(function () {
+				count.should.equal(1);
+				done()
+			}).catch(done);
+		});
+
 		it('should run a passed in function', function (done) {
 			var seq = new Sequelize(),
 				count = 0;


### PR DESCRIPTION
The method signature in sequelize-mock does not match the signature in 
sequelize. Specifically it should optionally accept an options Object as 
the first argument.